### PR TITLE
Script to delete tf-state bucket on stack_destroy

### DIFF
--- a/operations/deployment/terraform/bitops.after-deploy.d/delete-tf-state-bucket.sh
+++ b/operations/deployment/terraform/bitops.after-deploy.d/delete-tf-state-bucket.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ $TERRAFORM_DESTROY = true ]] ; then
+  echo "Destroying S3 buket"
+  aws s3 rb s3://$TF_STATE_BUCKET --force
+fi


### PR DESCRIPTION
No need to delete elb logs bucket as it's not created during creation. 

If added, should be managed from within Terraform.