### PR TITLE
Speed-up the Ansible deployment step by fine-tuning ansible.cfg

### DIFF
--- a/operations/deployment/ansible/ansible.cfg
+++ b/operations/deployment/ansible/ansible.cfg
@@ -6,4 +6,6 @@ host_key_checking = False
 transport = ssh
 
 [ssh_connection]
-ssh_args = -o ForwardAgent=yes
+# speed-up the connection by using pipelining, ControlPersist and ControlMaster
+pipelining = True
+ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=600s


### PR DESCRIPTION
This enhancement adjusts the settings allowing to re-use SSH connections and also rely on Ansible pipelining.

Fixes https://github.com/bitovi/github-actions-deploy-stackstorm/issues/41#issuecomment-1411217187 when the GH Action was ran for `1 hour` to set up StackStorm 🔴 .

For testing, 2 GH Actions pipelines, started around the same time against the same regions, same instance size.
* [left](https://github.com/bitovi/operations-stackstorm/actions/runs/4068344608/jobs/7006891727) - one with ansible.cfg optimizations
* [right](https://github.com/bitovi/operations-stackstorm/actions/runs/4068389540/jobs/7006881852) - without optimizations

https://user-images.githubusercontent.com/1533818/216165642-1b232b0f-c68b-4c94-a314-868c6ee27b58.mov


When `left` action finished the full StackStorm install with all the tests, the `right` action was still installing RabbitMQ.

The end results: `9mins` vs `40mins`. You can notice how things are not moving on the right side.

Turns out for some reason specific things are really slow on GH Actions.

Resources:
* https://www.redhat.com/sysadmin/faster-ansible-playbook-execution