### PR TITLE
Allow users to pass custom Ansible vars file

### DIFF
--- a/operations/_scripts/deploy/deploy.sh
+++ b/operations/_scripts/deploy/deploy.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
+set -e -o pipefail
 
 echo "In deploy.sh"
 GITHUB_REPO_NAME=$(echo $GITHUB_REPOSITORY | sed 's/^.*\///')
 
 # Generate buckets identifiers and check them agains AWS Rules
 export TF_STATE_BUCKET="$(/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/generate_buckets_identifiers.sh tf | xargs)"
-/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/deploy/check_bucket_name.sh $TF_STATE_BUCKET
+/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/check_bucket_name.sh $TF_STATE_BUCKET
 export LB_LOGS_BUCKET="$(/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/generate_buckets_identifiers.sh lb | xargs)"
-/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/deploy/check_bucket_name.sh $LB_LOGS_BUCKET
-
-# Generate buckets identifiers
-export TF_STATE_BUCKET="$(/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/generate_buckets_identifiers.sh tf | xargs)"
-export LB_LOGS_BUCKET="$(/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/generate_buckets_identifiers.sh lb | xargs)"
+/bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/check_bucket_name.sh $LB_LOGS_BUCKET
 
 # Generate subdomain
 /bin/bash $GITHUB_ACTION_PATH/operations/_scripts/generate/generate_subdomain.sh

--- a/operations/_scripts/generate/check_bucket_name.sh
+++ b/operations/_scripts/generate/check_bucket_name.sh
@@ -9,47 +9,47 @@ set -e
 function checkBucket() {
   # check length of bucket name
   if [[ ${#1} -lt 3 || ${#1} -gt 63 ]]; then
-    echo "::error::Bucket name must be between 3 and 63 characters long."
+    echo "::error::Bucket name '$1' must be between 3 and 63 characters long."
     exit 1
   fi
 
   # check that bucket name consists only of lowercase letters, numbers, dots (.), and hyphens (-)
   if [[ ! $1 =~ ^[a-z0-9.-]+$ ]]; then
-    echo "::error::Bucket name can only consist of lowercase letters, numbers, dots (.), and hyphens (-)."
+    echo "::error::Bucket name '$1' can only consist of lowercase letters, numbers, dots (.), and hyphens (-)."
     exit 1
   fi
 
   # check that bucket name begins and ends with a letter or number
   if [[ ! $1 =~ ^[a-zA-Z0-9] ]]; then
-    echo "::error::Bucket name must begin with a letter or number."
+    echo "::error::Bucket name '$1' must begin with a letter or number."
     exit 1
   fi
   if [[ ! $1 =~ [a-zA-Z0-9]$ ]]; then
-    echo "::error::Bucket name must end with a letter or number."
+    echo "::error::Bucket name '$1' must end with a letter or number."
     exit 1
   fi
 
   # check that bucket name does not contain two adjacent periods
   if [[ $1 =~ \.\. ]]; then
-    echo "::error::Bucket name cannot contain two adjacent periods."
+    echo "::error::Bucket name '$1' cannot contain two adjacent periods."
     exit 1
   fi
 
   # check that bucket name is not formatted as an IP address
   if [[ $1 =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-    echo "::error::Bucket name cannot be formatted as an IP address."
+    echo "::error::Bucket name '$1' cannot be formatted as an IP address."
     exit 1
   fi
 
   # check that bucket name does not start with the prefix xn--
   if [[ $1 =~ ^xn-- ]]; then
-    echo "::error::Bucket name cannot start with the prefix xn--."
+    echo "::error::Bucket name '$1' cannot start with the prefix xn--."
     exit 1
   fi
 
   # check that bucket name does not end with the suffix -s3alias
   if [[ $1 =~ -s3alias$ ]]; then
-    echo "::error::Bucket name cannot end with the suffix -s3alias."
+    echo "::error::Bucket name '$1' cannot end with the suffix -s3alias."
     exit 1
   fi
 }

--- a/operations/_scripts/generate/generate_buckets_identifiers.sh
+++ b/operations/_scripts/generate/generate_buckets_identifiers.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
-GITHUB_IDENTIFIER="$(echo $($GITHUB_ACTION_PATH/operations/_scripts/generate/generate_identifier.sh) | tr '[:upper:]' '[:lower:]' | tr '_' '-' )"
+GITHUB_IDENTIFIER="$(echo $($GITHUB_ACTION_PATH/operations/_scripts/generate/generate_identifier.sh) | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr '/' '.' )"
 
 case $1 in 
   tf)


### PR DESCRIPTION
Closes #7, closes #20, closes #32
Relies on [Bypass BITOPS_ extra ENV vars to Docker run #48](https://github.com/bitovi/github-actions-deploy-stackstorm/pull/48) which needs to be merged first.

Overwrites #32 which went a bit far in terms of complexity.

In general, we can just rely on built-in `BITOPS_ANSIBLE_EXTRA_VARS` ENV https://github.com/bitops-plugins/ansible#extra-vars implementation for user to specify the file with the Ansible vars. That'll provide the exactctly needed functionality for overriding the st2.conf and other advanced configuration.
The implementation could be simple as that, getting the best of BitOps VARs and the framework.


~Fix  BitOps 🐛 bug [CLI args to the plugins are not passed #360](https://github.com/bitovi/bitops/issues/360).~